### PR TITLE
Ensure drizzle-kit push uses TypeScript config

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
     "start": "NODE_ENV=production node dist/index.js",
     "check": "tsc",
-    "db:push": "drizzle-kit push"
+    "db:push": "drizzle-kit push --config=./drizzle.config.ts"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.10.0",


### PR DESCRIPTION
## Summary
- invoke drizzle-kit push with the explicit drizzle.config.ts file in the db:push npm script

## Testing
- DATABASE_URL=postgresql://postgres:postgres@localhost:5432/invoice_gen npm run db:push

------
https://chatgpt.com/codex/tasks/task_e_68cd895b9068832aa9be732b5a296d61