### PR TITLE
Update Docker build for Drizzle CLI

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+node_modules
+npm-debug.log
+Dockerfile
+Dockerfile.*
+.dockerignore
+dist
+.git
+.gitignore
+**/*.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,35 @@
+# syntax=docker/dockerfile:1.6
+
+FROM node:20-bullseye-slim AS base
+WORKDIR /app
+ENV NODE_ENV=production
+
+FROM node:20-bullseye-slim AS deps
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci
+
+FROM deps AS build
+ENV NODE_ENV=production
+COPY tsconfig.json vite.config.ts tailwind.config.ts postcss.config.js ./
+COPY components.json ./components.json
+COPY drizzle.config.ts ./drizzle.config.ts
+COPY shared ./shared
+COPY client ./client
+COPY server ./server
+COPY attached_assets ./attached_assets
+RUN --mount=type=bind,source=.,target=/src,ro \
+    if [ -d /src/migrations ]; then cp -R /src/migrations ./migrations; else mkdir -p ./migrations; fi
+RUN npm run build
+
+FROM base AS production
+COPY --from=deps /app/node_modules ./node_modules
+COPY --from=build /app/dist ./dist
+COPY package.json package-lock.json ./
+COPY --from=build /app/drizzle.config.ts ./drizzle.config.ts
+COPY --from=build /app/shared ./shared
+# Copy migrations if they exist in the build context
+COPY --from=build /app/migrations ./migrations
+COPY --from=build /app/tsconfig.json ./tsconfig.json
+
+CMD ["node", "dist/index.js"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,26 @@
+services:
+  db:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_DB: invoice
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -d invoice"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+    ports:
+      - "5432:5432"
+  invoice-app:
+    build:
+      context: .
+      target: production
+    depends_on:
+      db:
+        condition: service_healthy
+    environment:
+      DATABASE_URL: postgres://postgres:postgres@db:5432/invoice
+      DATABASE_USE_NEON_WEBSOCKETS: "false"
+    command: ["node", "dist/index.js"]
+    tty: true


### PR DESCRIPTION
## Summary
- ensure the production image copies drizzle.config.ts, shared schema files, and optional migrations so Drizzle CLI can run inside the container
- add a dockerignore to keep the build context small
- add a docker compose definition with a Postgres dependency configured for the invoice app

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cd8cae29d8832a95187f6ef3f09082